### PR TITLE
Define Looks Prim

### DIFF
--- a/ShdrPlygrnd/materials/materials_openPBR.usda
+++ b/ShdrPlygrnd/materials/materials_openPBR.usda
@@ -51,3 +51,10 @@
         @./yellowPaint.usda@
     ]
 )
+
+over "World"
+{
+    def Scope "Looks"
+    {
+    }
+}


### PR DESCRIPTION
Defines the `/World/Looks` Prim as `Scope`. This allows the material Prims to be accessible in DCCs that might otherwise implicitly filter undefined Prims, such as Maya's outliner.