### PR TITLE
Fixes typos / type names so all OpenPBR surface shaders are defined in USD

### DIFF
--- a/ShdrPlygrnd/materials/chairA.mtlx
+++ b/ShdrPlygrnd/materials/chairA.mtlx
@@ -52,7 +52,7 @@
     <input name="coat_ior" type="float" value="1.5" />
     <input name="base_color" type="color3" nodename="BaseColor" />
     <input name="base_metalness" type="float" nodename="Metalness" />
-    <input name="specular_color" type="float" value="0.62893, 0.62893, 0.62893" />
+    <input name="specular_color" type="color3" value="0.62893, 0.62893, 0.62893" />
     <input name="specular_roughness" type="float" nodename="Roughness" />
     <input name="geometry_normal" type="vector3" nodename="mtlxnormalmap1" />
   </open_pbr_surface>

--- a/ShdrPlygrnd/materials/eraser.mtlx
+++ b/ShdrPlygrnd/materials/eraser.mtlx
@@ -47,7 +47,7 @@
 
   <open_pbr_surface name="mtlxopen_pbr_surface" type="surfaceshader">
     <input name="base_color" type="color3" nodename="BaseColor" />
-    <input name="basse_metalness" type="float" nodename="Metalness" />
+    <input name="base_metalness" type="float" nodename="Metalness" />
     <input name="specular_roughness" type="float" nodename="Roughness" />
     <input name="geometry_normal" type="vector3" nodename="mtlxnormalmap1" />
   </open_pbr_surface>

--- a/ShdrPlygrnd/materials/lampBulb.mtlx
+++ b/ShdrPlygrnd/materials/lampBulb.mtlx
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <materialx version="1.39" colorspace="lin_rec709">
   <open_pbr_surface name="mtlxopen_pbr_surface" type="surfaceshader">
-    <input name="emission_luminance" type="value" value="70" />
+    <input name="emission_luminance" type="float" value="70" />
     <input name="emission_color" type="color3" value="0.324, 0.11215, 0" />
     <input name="specular_roughness" type="float" value="0" />
   </open_pbr_surface>

--- a/ShdrPlygrnd/materials/masonJarWater.mtlx
+++ b/ShdrPlygrnd/materials/masonJarWater.mtlx
@@ -18,7 +18,7 @@
     <input name="specular_roughness" type="float" value="0.1" />
     <input name="specular_roughness_anisotropy" type="float" value="0.5" />
     <input name="subsurface_color" type="color3" nodename="ScatterColor" />
-    <input name="subsurface_radius" type="value" value="5" />
+    <input name="subsurface_radius" type="float" value="5" />
     <input name="subsurface_radius_scale" type="color3" value="0.045, 0.02021, 0.02366" />
     <input name="transmission_weight" type="float" value="0.17308" />
     <input name="transmission_depth" type="float" value="2" />

--- a/ShdrPlygrnd/materials/wings.mtlx
+++ b/ShdrPlygrnd/materials/wings.mtlx
@@ -53,7 +53,8 @@
     <input name="base_color" type="color3" nodename="BaseColor" />
     <input name="base_metalness" type="float" nodename="Metalness" />
     <input name="specular_roughness" type="float" nodename="Roughness" />
-    <input name="geometry_opacity" type="float" nodename="Opacity" />
+    <!-- FIXME: Issue with Opacity UDIM in Arnold>
+    <input name="geometry_opacity" type="float" nodename="Opacity" /-->
     <input name="geometry_normal" type="vector3" nodename="mtlxnormalmap1" />
   </open_pbr_surface>
 


### PR DESCRIPTION
Fixes a few typos and incorrect type names (according to OpenPBR spec). This was preventing the creation of `ND_open_pbr_surface_surfaceshader` Shader Prims in USD via `UsdMtlx`, resulting in broken and unimageable materials.

Additionally, temporarily disables opacity on the plane wing material, as the combination of opacity + single bound UDIM textures (but not 1001) + Arnold was resulting in unimageable wings (interesting that the issue only impacts opacity, and not the other textures like base color).