### PR TITLE
Fix UsdValidation reporting errors

### DIFF
--- a/ShdrPlygrnd/materials/OJ.mtlx
+++ b/ShdrPlygrnd/materials/OJ.mtlx
@@ -5,7 +5,7 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/OJ_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/OJ_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/OJfoam.mtlx
+++ b/ShdrPlygrnd/materials/OJfoam.mtlx
@@ -5,11 +5,11 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/OJfoam_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/OJfoam_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/OJfoam_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/OJfoam_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/OJglass.mtlx
+++ b/ShdrPlygrnd/materials/OJglass.mtlx
@@ -5,11 +5,11 @@
   </geompropvalue>
 
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/OJglass_MAT_Roughness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/OJglass_MAT_Roughness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/OJglass_MAT_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/OJglass_MAT_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/baby_sneakers.mtlx
+++ b/ShdrPlygrnd/materials/baby_sneakers.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/kidShoe_MAT_BaseColor.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/kidShoe_MAT_BaseColor.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/kidShoe_MAT_Metalness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/kidShoe_MAT_Metalness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/kidShoe_MAT_Roughness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/kidShoe_MAT_Roughness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/kidShoe_MAT_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/kidShoe_MAT_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/books.mtlx
+++ b/ShdrPlygrnd/materials/books.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/books_MAT_BaseColor.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/books_MAT_BaseColor.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/books_MAT_Roughness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/books_MAT_Roughness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/books_MAT_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/books_MAT_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/bottle.mtlx
+++ b/ShdrPlygrnd/materials/bottle.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/bottle_MAT_BaseColor.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/bottle_MAT_BaseColor.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="color3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/bottle_MAT_Roughness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/bottle_MAT_Roughness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/bottle_MAT_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/bottle_MAT_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/bubblesMasonJar.mtlx
+++ b/ShdrPlygrnd/materials/bubblesMasonJar.mtlx
@@ -5,7 +5,7 @@
   </geompropvalue>
 
   <image name="ScatterColor" type="color3">
-      <input name="file" type="filename" colorspace="raw" value="textures/masonJarLiquid_transScatterColor.jpg" />
+      <input name="file" type="filename" colorspace="raw" value="../textures/masonJarLiquid_transScatterColor.jpg" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/ceramicMug.mtlx
+++ b/ShdrPlygrnd/materials/ceramicMug.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/ceramicMug_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/ceramicMug_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Coat_Weight" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/ceramicMug_MAT_CoatMask.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/ceramicMug_MAT_CoatMask.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/ceramicMug_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/ceramicMug_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/ceramicMug_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/ceramicMug_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/chairA.mtlx
+++ b/ShdrPlygrnd/materials/chairA.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/chair_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/chair_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/chair_MAT_Metalness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/chair_MAT_Metalness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/chair_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/chair_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/chair_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/chair_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/crumpledPaper.mtlx
+++ b/ShdrPlygrnd/materials/crumpledPaper.mtlx
@@ -5,11 +5,11 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/paperCrumpled_BaseColor.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/paperCrumpled_BaseColor.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/paperCrumpled_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/paperCrumpled_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/drapedFabric.mtlx
+++ b/ShdrPlygrnd/materials/drapedFabric.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/drapedFabric_MAT_BaseColor.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/drapedFabric_MAT_BaseColor.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/drapedFabric_MAT_Roughness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/drapedFabric_MAT_Roughness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/drapedFabric_MAT_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/drapedFabric_MAT_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/dresser.mtlx
+++ b/ShdrPlygrnd/materials/dresser.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/dresser_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/dresser_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/dresser_MAT_Metalness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/dresser_MAT_Metalness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/dresser_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/dresser_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/dresser_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/dresser_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/eraser.mtlx
+++ b/ShdrPlygrnd/materials/eraser.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/pencilColored_MAT_BaseColor.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/pencilColored_MAT_BaseColor.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/pencilColored_MAT_Metalness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/pencilColored_MAT_Metalness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/pencilColored_MAT_Roughness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/pencilColored_MAT_Roughness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/pencilColored_MAT_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/pencilColored_MAT_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/floor.mtlx
+++ b/ShdrPlygrnd/materials/floor.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/floor_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/floor_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/floor_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/floor_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/floor_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/floor_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/iceCube.mtlx
+++ b/ShdrPlygrnd/materials/iceCube.mtlx
@@ -5,11 +5,11 @@
   </geompropvalue>
 
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/iceCube_rougness.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/iceCube_rougness.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Bump" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/iceCube_grunge1.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/iceCube_grunge1.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/iceCubesInner.mtlx
+++ b/ShdrPlygrnd/materials/iceCubesInner.mtlx
@@ -5,7 +5,7 @@
   </geompropvalue>
 
   <image name="Opacity" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/iceCube_grunge1.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/iceCube_grunge1.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/lamp.mtlx
+++ b/ShdrPlygrnd/materials/lamp.mtlx
@@ -5,23 +5,23 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/lamp_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/lamp_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Coat_Weight" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/lamp_MAT_CoatMask.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/lamp_MAT_CoatMask.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/lamp_MAT_Metalness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/lamp_MAT_Metalness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/lamp_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/lamp_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/lamp_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/lamp_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/lampShade.mtlx
+++ b/ShdrPlygrnd/materials/lampShade.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/lampShade_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/lampShade_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/lampShade_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/lampShade_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/lampShade_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/lampShade_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/masonJarGlass.mtlx
+++ b/ShdrPlygrnd/materials/masonJarGlass.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/masonJar_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/masonJar_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/masonJar_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/masonJar_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Transmission" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/masonJar_MAT_TransMask.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/masonJar_MAT_TransMask.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/masonJar_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/masonJar_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/masonJarWater.mtlx
+++ b/ShdrPlygrnd/materials/masonJarWater.mtlx
@@ -5,7 +5,7 @@
   </geompropvalue>
 
   <image name="ScatterColor" type="color3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/masonJarLiquid_transScatterColorPurple.jpg" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/masonJarLiquid_transScatterColorPurple.jpg" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/meetMAT.mtlx
+++ b/ShdrPlygrnd/materials/meetMAT.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/meetMAT_MAT_BaseColor.1001.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/meetMAT_MAT_BaseColor.1001.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Emissive" type="color3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/meetMAT_MAT_Emissive.1001.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/meetMAT_MAT_Emissive.1001.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/meetMAT_MAT_BaseColor.1001.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/meetMAT_MAT_BaseColor.1001.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/meetMAT_MAT_Normal.1001.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/meetMAT_MAT_Normal.1001.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/pacifier.mtlx
+++ b/ShdrPlygrnd/materials/pacifier.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/pacifier_MAT_BaseColor.1011.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/pacifier_MAT_BaseColor.1011.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/pacifier_MAT_Roughness.1011.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/pacifier_MAT_Roughness.1011.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/pacifier_MAT_Normal.1011.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/pacifier_MAT_Normal.1011.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/pacifierRubber.mtlx
+++ b/ShdrPlygrnd/materials/pacifierRubber.mtlx
@@ -5,11 +5,11 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/pacifier_MAT_BaseColor.1011.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/pacifier_MAT_BaseColor.1011.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/pacifier_MAT_Normal.1011.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/pacifier_MAT_Normal.1011.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/paintBrushes.mtlx
+++ b/ShdrPlygrnd/materials/paintBrushes.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/paintBrushes_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/paintBrushes_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/paintBrushes_MAT_Metalness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/paintBrushes_MAT_Metalness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/paintBrushes_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/paintBrushes_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/paintBrushes_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/paintBrushes_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/paintBrushesSML.mtlx
+++ b/ShdrPlygrnd/materials/paintBrushesSML.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/paintBrushesSML_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/paintBrushesSML_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/paintBrushesSML_MAT_Metalness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/paintBrushesSML_MAT_Metalness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/paintBrushesSML_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/paintBrushesSML_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/paintBrushesSML_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/paintBrushesSML_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/paintSpill.mtlx
+++ b/ShdrPlygrnd/materials/paintSpill.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/paintSpills_MAT_BaseColor.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/paintSpills_MAT_BaseColor.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/paintSpills_MAT_Roughness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/paintSpills_MAT_Roughness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/paintSpills_MAT_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/paintSpills_MAT_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/paintSpill.usda
+++ b/ShdrPlygrnd/materials/paintSpill.usda
@@ -160,7 +160,6 @@ over "World"
                 prepend apiSchemas = ["MaterialBindingAPI"]
             )
             {
-                uniform token familyName = "materialBind"
                 rel material:binding = </World/Looks/paintSpill>
             }
         }

--- a/ShdrPlygrnd/materials/paper.mtlx
+++ b/ShdrPlygrnd/materials/paper.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/chairPaper_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/chairPaper_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="SSSweight" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/chairPaper_MAT_SSSwght.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/chairPaper_MAT_SSSwght.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/chairPaper_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/chairPaper_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/paperPlans.mtlx
+++ b/ShdrPlygrnd/materials/paperPlans.mtlx
@@ -5,7 +5,7 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/plans_diffuse.jpg" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/plans_diffuse.jpg" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/pencil.mtlx
+++ b/ShdrPlygrnd/materials/pencil.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/pencil_MAT_BaseColor.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/pencil_MAT_BaseColor.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/pencil_MAT_Metalness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/pencil_MAT_Metalness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/pencil_MAT_Roughness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/pencil_MAT_Roughness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/pencil_MAT_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/pencil_MAT_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/planePlastic.mtlx
+++ b/ShdrPlygrnd/materials/planePlastic.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/planePlastic_MAT_BaseColor.1012.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/planePlastic_MAT_BaseColor.1012.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/planePlastic_MAT_Roughness.1012.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/planePlastic_MAT_Roughness.1012.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/planePlastic_MAT_Normal.1012.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/planePlastic_MAT_Normal.1012.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/planePlasticLidWheels.mtlx
+++ b/ShdrPlygrnd/materials/planePlasticLidWheels.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/planePlastic_MAT_BaseColor.1012.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/planePlastic_MAT_BaseColor.1012.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/planePlastic_MAT_Roughness.1012.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/planePlastic_MAT_Roughness.1012.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/planePlastic_MAT_Normal.1012.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/planePlastic_MAT_Normal.1012.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/shadow.mtlx
+++ b/ShdrPlygrnd/materials/shadow.mtlx
@@ -5,7 +5,7 @@
   </geompropvalue>
 
   <image name="BaseColor" type="float">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/shadow_BaseColor.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/shadow_BaseColor.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/toolsMetal.mtlx
+++ b/ShdrPlygrnd/materials/toolsMetal.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/toolsMetal_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/toolsMetal_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/toolsMetal_MAT_Metalness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/toolsMetal_MAT_Metalness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/toolsMetal_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/toolsMetal_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/toolsMetal_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/toolsMetal_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/toolsPlastic.mtlx
+++ b/ShdrPlygrnd/materials/toolsPlastic.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/toolsPlastic_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/toolsPlastic_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/toolsPlastic_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/toolsPlastic_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/toolsPlastic_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/toolsPlastic_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/towels.mtlx
+++ b/ShdrPlygrnd/materials/towels.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/towels_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/towels_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/towels_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/towels_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/towels_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/towels_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/tube.mtlx
+++ b/ShdrPlygrnd/materials/tube.mtlx
@@ -5,19 +5,19 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/tube_MAT_BaseColor.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/tube_MAT_BaseColor.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/tube_MAT_Metalness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/tube_MAT_Metalness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/tube_MAT_Roughness.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/tube_MAT_Roughness.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/tube_MAT_Normal.<UDIM>.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/tube_MAT_Normal.<UDIM>.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/walls.mtlx
+++ b/ShdrPlygrnd/materials/walls.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/walls_BaseColor.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/walls_BaseColor.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/wall_Roughness.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/wall_Roughness.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/walls_Normal.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/walls_Normal.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/wings.mtlx
+++ b/ShdrPlygrnd/materials/wings.mtlx
@@ -5,23 +5,23 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/wings_MAT_BaseColor.png" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/wings_MAT_BaseColor.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Metalness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/wings_MAT_Metalness.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/wings_MAT_Metalness.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/wings_MAT_Roughness.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/wings_MAT_Roughness.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Opacity" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/wings_MAT_Opacity.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/wings_MAT_Opacity.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/wings_MAT_Normal.png" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/wings_MAT_Normal.png" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 

--- a/ShdrPlygrnd/materials/wood_chair_seat_mesh.mtlx
+++ b/ShdrPlygrnd/materials/wood_chair_seat_mesh.mtlx
@@ -5,15 +5,15 @@
   </geompropvalue>
 
   <image name="BaseColor" type="color3">
-      <input name="file" type="filename" colorspace="srgb_tx" value="textures/chairB_MAT_BaseColor.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="srgb_tx" value="../textures/chairB_MAT_BaseColor.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Roughness" type="float">
-      <input name="file" type="filename" colorspace="Raw" value="textures/chairB_MAT_Roughness.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/chairB_MAT_Roughness.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
   <image name="Normal" type="vector3">
-      <input name="file" type="filename" colorspace="Raw" value="textures/chairB_MAT_Normal.<UDIM>.tif" />
+      <input name="file" type="filename" colorspace="Raw" value="../textures/chairB_MAT_Normal.<UDIM>.tif" />
       <input name="texcoord" type="vector2" nodename="st" />
   </image>
 


### PR DESCRIPTION
This PR fixes issue [#21](https://github.com/DigitalProductionExampleLibrary/OpenPBRShaderPlayground/issues/21) created.

So there are 3 validation error types, and 400+ errors of those:

1. `InvalidMaterialCollection` - 326 errors because the binary geo file (ShdrPlygrnd_Geo.usd) has `rel material:binding = None` on 359 prims which is explicitly preventing material assignments. Removing that gets rid of these errors.
2. `UnresolvableDependency` - 110 errors because texture references across 39 mtlx files are textures/ and not relative path to usda so should be `../textures/`.
3. `InvalidSubsetFamily` - 1 error. One thing that is present in a material subLayer is a GeomSubset child override with `uniform token familyName = "materialBind"` which is not present for any other child. This suggests a duplication as [the familyType of the UsdGeomSubsets](https://openusd.org/dev/api/class_usd_geom_subset.html#af278c1bd6603a66ffcb1a033f395a876) in this case is of type `UsdGeomTokens->partition` which means from the docs - every element of the whole geometry appears exactly once in only one of the subsets belonging to the family. So in the `ShdrPlygrnd_Geo.usd` file we are already specifying the family name for all `GeomSubsets` so this one is not necessary which is why the validation error appears.

The PR is best reviewed commit by commit as each one presents a solution to each of these errors as the names of the commit suggests.